### PR TITLE
Include hidden files in upload artifact action

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: ./api/public
+          include-hidden-files: true
 
   deploy_api:
     name: Deploy API

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -54,6 +54,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: ./images/public
+          include-hidden-files: true
 
   deploy_images:
     name: Deploy images

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -69,6 +69,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: ./website/out
+          include-hidden-files: true
 
   deploy:
     environment:


### PR DESCRIPTION
- Include hidden files in upload artifact action
- The .nojekyll file wasn't uploaded by the upload artifact action after migrating to v4 as that's the breaking change
- We need this .nojekyll file for next static assets to load https://github.com/clydedsouza/clydedsouza-monorepo/commit/77688e50f23ca609f174c90275810751176fb893